### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Use the `redis` option to configure the redis connection, or use the `redis` env
 
 ```bash
 
-NUXT_REDIS_HOST='localhost'
-NUXT_REDIS_PORT=6379
-NUXT_REDIS_PASSWORD=''
+NUXT_CONCIERGE_REDIS_HOST='localhost'
+NUXT_CONCIERGE_REDIS_PORT=6379
+NUXT_CONCIERGE_REDIS_PASSWORD=''
 ```
 
 **Note**: A redis connetion **is required** for this module to work.

--- a/src/module.ts
+++ b/src/module.ts
@@ -39,9 +39,9 @@ export default defineNuxtModule<ModuleOptions>({
       boardTitle: "Concierge",
     },
     redis: {
-      host: process.env.NUXT_REDIS_HOST,
-      port: Number(process.env.NUXT_REDIS_PORT),
-      password: process.env.NUXT_REDIS_PASSWORD,
+      host: process.env.NUXT_CONCIERGE_REDIS_HOST,
+      port: Number(process.env.NUXT_CONCIERGE_REDIS_PORT),
+      password: process.env.NUXT_CONCIERGE_REDIS_PASSWORD,
     },
     queues: [],
     managementUI: process.env.NODE_ENV === "development",


### PR DESCRIPTION
This corrects the names of the runtime environment variables necessary to override the redis connection config option


Thanks for the great work on the package btw, it's a godsend!